### PR TITLE
Adds ssh port and proper arguments parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@
 
 **Run CLI**
 
-The following will request server ssh pubkey through a proxy, and separately run ssh-keyscan and will return the matching server keys that you can then append to your known_hosts.  
+The following will request server ssh pubkey through a proxy, and separately run ssh-keyscan and will return the matching server keys that you can then append to your known_hosts.
 
 ```bash
-./cmd/cli/add_to_known_hosts.sh <attested http proxy> <host ip> >> ~/.ssh/known_hosts
+$ bash ./cmd/cli/add_to_known_hosts.sh --help
+Makes sure the pubkey returned from proxy matches ssh-keyscan of the host, and formats in a way that can be appended to known_hosts.
+Usage:	./add_to_known_hosts.sh [--proxy=http://127.0.0.1:8080] --ssh-host=<hosts ip> [--ssh-port=22] >> ~/.ssh/known_hosts
+	Make sure your cvm-reverse-proxy client is running.
 ```
 
 **Build HTTP server**

--- a/cmd/cli/add_to_known_hosts.sh
+++ b/cmd/cli/add_to_known_hosts.sh
@@ -1,12 +1,37 @@
-#!/bin/sh
+#!/bin/bash
 
-# Usage: ./add_to_known_hosts.sh <http proxy> <host ip> >> ~/.ssh/known_hosts
-# Makes sure the pubkey returned from proxy matches ssh-keyscan of the host, and formats in a way that can be appended to known_hosts
+# For help run with -h
 
-if [ $1 = "-h" ]; then
-	echo "Usage: ./add_to_known_hosts.sh <http proxy> <host ip> >> ~/.ssh/known_hosts (or append manually)"
-	exit 0;
+usage() {
+	echo -e "Makes sure the pubkey returned from proxy matches ssh-keyscan of the host, and formats in a way that can be appended to known_hosts.\nUsage:\t./add_to_known_hosts.sh [--proxy=http://127.0.0.1:8080] --ssh-host=<hosts ip> [--ssh-port=22] >> ~/.ssh/known_hosts\n\tMake sure your cvm-reverse-proxy client is running."
+}
+
+PORT=22
+PROXY="http://127.0.0.1:8080"
+
+for i in "$@"
+do
+case $i in
+    --proxy=*)
+		PROXY="${i#*=}"
+		;;
+    --ssh-host=*)
+		HOST="${i#*=}"
+		;;
+    --ssh-port=*)
+		PORT="${i#*=}"
+		;;
+    -h|--help|*)
+		usage
+		exit 0
+		;;
+esac
+done
+
+if [[ -z "$HOST" ]]; then
+	usage
+	exit 1
 fi
 
-pubkey=`curl -s $1/pubkey`
-ssh-keyscan -H "$2" 2>/dev/null | grep "${pubkey}"
+pubkey=`curl -s $PROXY/pubkey`
+ssh-keyscan -p "$PORT" -H "$HOST" 2>/dev/null | grep "${pubkey}"

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -26,7 +26,7 @@ var flags []cli.Flag = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:  "metrics-addr",
-		Value: "127.0.0.1:8090",
+		Value: "",
 		Usage: "address to listen on for Prometheus metrics",
 	},
 	&cli.BoolFlag{
@@ -46,7 +46,7 @@ var flags []cli.Flag = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:  "log-service",
-		Value: "your-project",
+		Value: "ssh-pubkey-server",
 		Usage: "add 'service' tag to logs",
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
## 📝 Summary

Adds ssh port and proper arguments parsing.
Disables metrics server by default.

## ⛱ Motivation and Context

Script needs to support non-standard ports.

## 📚 References

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
