### PR TITLE
Add cli option for passing a second key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ make build-httpserver
 **Run pubkey server**
 
 ```bash
-go run ./cmd/httpserver/main.go [--listen-addr=127.0.0.1:8080] [--ssh-pubkey-file=/etc/ssh/ssh_host_ed25519_key.pub]
+go run ./cmd/httpserver/main.go [--listen-addr=127.0.0.1:8080] [--host-ssh-pubkey-file=/etc/ssh/ssh_host_ed25519_key.pub] [--container-ssh-pubkey-file=/path/to/container_key.pub]
 ```
+
+The server will serve both pubkeys (if provided) at the `/pubkey` endpoint, separated by a newline. The `--container-ssh-pubkey-file` flag is optional.
 
 **Install dev dependencies**
 

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -15,9 +15,14 @@ import (
 
 var flags []cli.Flag = []cli.Flag{
 	&cli.StringFlag{
-		Name:  "ssh-pubkey-file",
+		Name:  "host-ssh-pubkey-file",
 		Value: "/etc/ssh/ssh_host_ed25519_key.pub",
-		Usage: "path to file containing pubkey to serve",
+		Usage: "path to file containing host pubkey to serve",
+	},
+	&cli.StringFlag{
+		Name:  "container-ssh-pubkey-file",
+		Value: "",
+		Usage: "path to file containing container pubkey to serve",
 	},
 	&cli.StringFlag{
 		Name:  "listen-addr",
@@ -99,7 +104,8 @@ func main() {
 				ReadTimeout:              60 * time.Second,
 				WriteTimeout:             30 * time.Second,
 
-				SSHPubkeyPath: cCtx.String("ssh-pubkey-file"),
+				HostSSHPubkeyPath:      cCtx.String("host-ssh-pubkey-file"),
+				ContainerSSHPubkeyPath: cCtx.String("container-ssh-pubkey-file"),
 			}
 
 			srv, err := httpserver.New(cfg)

--- a/httpserver/handler.go
+++ b/httpserver/handler.go
@@ -18,7 +18,7 @@ func (s *Server) handleGetPubkey(w http.ResponseWriter, r *http.Request) {
 		m.Record(r.Context(), float64(time.Since(start).Microseconds()))
 	}(time.Now())
 
-	_, err := w.Write(s.sshPubkey)
+	_, err := w.Write(s.sshPubkeys)
 	if err != nil {
 		s.log.Error("could not serve pubkey", "err", err)
 	}

--- a/httpserver/handler_test.go
+++ b/httpserver/handler_test.go
@@ -29,10 +29,11 @@ func Test_Handlers_Healthcheck_Drain_Undrain(t *testing.T) {
 
 	//nolint: exhaustruct
 	s, err := New(&HTTPServerConfig{
-		DrainDuration: latency,
-		ListenAddr:    listenAddr,
-		Log:           getTestLogger(),
-		SSHPubkeyPath: "./test_key.pub",
+		DrainDuration:          latency,
+		ListenAddr:             listenAddr,
+		Log:                    getTestLogger(),
+		HostSSHPubkeyPath:      "./test_key.pub",
+		ContainerSSHPubkeyPath: "./test_key.pub",
 	})
 	require.NoError(t, err)
 
@@ -45,7 +46,10 @@ func Test_Handlers_Healthcheck_Drain_Undrain(t *testing.T) {
 		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, data, []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFGGVd5nQewq0hETk2Tr/P7OZxTW/4aftdfh9/cAe7FC"))
+		expectedKey := []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFGGVd5nQewq0hETk2Tr/P7OZxTW/4aftdfh9/cAe7FC")
+		expectedOutput := append(expectedKey, '\n')
+		expectedOutput = append(expectedOutput, expectedKey...)
+		require.Equal(t, data, expectedOutput)
 	}
 
 	{ // Check health


### PR DESCRIPTION
## 📝 Summary

- Replace single `--ssh-pubkey-file` with `--host-ssh-pubkey-file` and `--container-ssh-pubkey-file` flags
- Serve both pubkeys at `/pubkey` endpoint, separated by a newline
- Container pubkey is optional

## ⛱ Motivation and Context

- Now that the searcher provides their encryption password over an SSH to the CVM host (dropbear), we need to provide both keys to prevent an MITM attack
- The searcher can just copy the text into known_hosts as before

---

## ✅ I have run these commands

* [X] `make lint`
* [X] `make test`
* [X] `go mod tidy`